### PR TITLE
Fix fatal error when custom posts page is set

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@
 					<?php echo get_page($blog_page_id)->post_title; ?>
 				</h2>
 				<aside class="page-meta">
-					<?php current_paged(); ?>
+					<?php oblivion_current_paged(); ?>
 				</aside>
 			</div>
 		</header>


### PR DESCRIPTION
The following error appeared after a custom posts page has been set.

`PHP Fatal error:  Call to undefined function current_paged() in wordpress\wp-content\themes\Oblivion-master\index.php on line 13`
